### PR TITLE
Create enforce-pr-only-main.yaml

### DIFF
--- a/.github/workflows/enforce-pr-only-main.yaml
+++ b/.github/workflows/enforce-pr-only-main.yaml
@@ -1,0 +1,24 @@
+name: Enforce PR for main branch
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  enforce-pr:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check if the push is from a PR
+      run: |
+        if [ "${{ github.event_name }}" != "pull_request" ]; then
+          echo "Pushes to main branch are only allowed through a pull request from the dev branch."
+          exit 1
+        fi
+
+    - name: Check if the PR is from dev branch
+      if: ${{ github.event.pull_request.head.ref != 'dev' }}
+      run: |
+        echo "The pull request must come from the dev branch."
+        exit 1


### PR DESCRIPTION
## Description

Will only allow PR request into `main` branch from the `dev` branch.
Should help with silly mistakes when pushing commits or creating PRs.