### PR TITLE
The watchlist view needs to be private

### DIFF
--- a/auctions/urls.py
+++ b/auctions/urls.py
@@ -13,5 +13,5 @@ urlpatterns = [
     path("register", views.register, name="register"),
     path("categories", views.categories, name="categories"),
     path("listing/<int:listing_id>", views.listing, name="listing"),
-    path("<int:user_id>/watchlist", views.watchlist, name="watchlist"),
+    path("watchlist", views.watchlist, name="watchlist"),
 ]

--- a/auctions/views.py
+++ b/auctions/views.py
@@ -66,7 +66,7 @@ def login_view(request):
         # Check if authentication successful
         if user is not None:
             login(request, user)
-            return HttpResponseRedirect(reverse("index"))
+            return HttpResponseRedirect(reverse("auctions:index"))
         else:
             return render(request, "auctions/login.html", {
                 "message": "Invalid username and/or password."
@@ -77,7 +77,7 @@ def login_view(request):
 
 def logout_view(request):
     logout(request)
-    return HttpResponseRedirect(reverse("index"))
+    return HttpResponseRedirect(reverse("auctions:index"))
 
 
 def register(request):
@@ -102,6 +102,6 @@ def register(request):
                 "message": "Username already taken."
             })
         login(request, user)
-        return HttpResponseRedirect(reverse("index"))
+        return HttpResponseRedirect(reverse("auctions:index"))
     else:
         return render(request, "auctions/register.html")

--- a/auctions/views.py
+++ b/auctions/views.py
@@ -1,4 +1,5 @@
 from django.contrib.auth import authenticate, login, logout
+from django.contrib.auth.decorators import login_required
 from django.db import IntegrityError
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import render
@@ -44,6 +45,7 @@ def listing(request, listing_id):
     })
 
 
+@login_required(login_url='/login')
 def watchlist(request, user_id):
     # load watchlist items by user id
     user = User.objects.get(pk=user_id)

--- a/auctions/views.py
+++ b/auctions/views.py
@@ -2,7 +2,7 @@ from django.contrib.auth import authenticate, login, logout
 from django.contrib.auth.decorators import login_required
 from django.db import IntegrityError
 from django.http import HttpResponse, HttpResponseRedirect
-from django.shortcuts import render
+from django.shortcuts import render, redirect
 from django.urls import reverse
 
 from .models import User, Listing, Category
@@ -46,9 +46,9 @@ def listing(request, listing_id):
 
 
 @login_required(login_url='/login')
-def watchlist(request, user_id):
+def watchlist(request):
     # load watchlist items by user id
-    user = User.objects.get(pk=user_id)
+    user = User.objects.get(pk=request.user.id)
     watchlist = user.watchlist.all()
     return render(request, "auctions/watchlist.html", {
         "watchlist": watchlist


### PR DESCRIPTION
## Description

- Removes the `user_id` parameter from the path to `watchlist`
- Add `login_required` wrapper on the `watchlist` view
- Removes the use of the `user_id` parameter in the view
- The `watchlist` view uses the id of the logged in user to request database watchlist